### PR TITLE
chore: declare all ecosystems present in this repo to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "deps(ruby)"
+      prefix: "deps(actions)"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps(ruby)"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Why

This repo has a `.github/dependabot.yml`, so it looks monitored — but a portfolio-wide scan found these ecosystems present in the tree and **undeclared**, meaning nothing watches them for security or version updates:

```
github-actions
```

Partial coverage is the more common failure mode than missing Dependabot outright, precisely because the repo appears covered. 9 repos across the four orgs were in this state.

## What

Adds one entry per missing ecosystem, following this file's existing conventions (indentation, quoting, schedule, labels/ignore where present). Nothing existing is changed.

Directories were resolved from the actual file locations in the tree rather than assumed.

## Note

Per [guidance#14](https://github.com/vln-devsecops/guidance/pull/14), the standing rules are: every ecosystem actually present should be declared, and every repo with Dependabot should have auto-merge — the latter once it has at least one PR-triggered check for the gate to wait on.